### PR TITLE
Windows-Kompatibilität

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,6 @@
 - `yarn update-server` ausführen, damit der server im Verzeichnis `server` verfügbar wird (dieser Schritt muss zum updaten des servers wiederholt werden)
 - GUI per `yarn start` starten
 
-### Bei Problemen mit Windows-User
-Es kann eine manuelle Installation von [Kotlin](https://downlinko.com/download-install-kotlin-windows.html) sowie [Gradle](https://gradle.org/install/) erforderlich sein, sollte die Fehlermeldung von `missing tools` auftreten.
-
 ## Allgemeine Struktur
 
 Es gibt drei Teile, jeweils in einem eigenen Hauptverzeichnis unter [src](src) GUI, API und Viewer.
@@ -56,3 +53,9 @@ Es wird auch immer ein Game Server mit in den Release gepackt. Dieser sollte vor
 *Fehler:* `Error: Exit code: ENOENT. spawn xorriso ENOENT`
 
 *Loesung:* xorriso installieren
+
+### Bei Problemen unter Windows
+
+Es kann eine manuelle Installation von [Kotlin](https://downlinko.com/download-install-kotlin-windows.html) sowie [Gradle](https://gradle.org/install/) erforderlich sein, sollte die Fehlermeldung von `missing tools` auftreten bei der Ausführung von `yarn update-server`
+
+Es wird die Windows-CMD sowie PowerShell [nicht unterstützt](https://github.com/CAU-Kiel-Tech-Inf/socha-gui/pull/26/commits/6ad684bf0af5b79e4b923f272022f64b2a60f35b). Eine Bash-Shell ist notwendig wie beispielsweise [git for windows](https://gitforwindows.org/)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@
 - `yarn update-server` ausführen, damit der server im Verzeichnis `server` verfügbar wird (dieser Schritt muss zum updaten des servers wiederholt werden)
 - GUI per `yarn start` starten
 
+### Für Windows-User
+
+- repository klonen
+- yarn und node installieren (evtl. muss auch noch [Kotlin](https://downlinko.com/download-install-kotlin-windows.html) sowie [Gradle](https://gradle.org/install/) manuell installiert werden)
+- `yarn update-server-win` ausführen, damit der server im Verzeichnis `server` verfügbar wird (dieser Schritt muss zum updaten des servers wiederholt werden)
+- GUI per `yarn start-win` starten
+
 ## Allgemeine Struktur
 
 Es gibt drei Teile, jeweils in einem eigenen Hauptverzeichnis unter [src](src) GUI, API und Viewer.

--- a/README.md
+++ b/README.md
@@ -15,12 +15,8 @@
 - `yarn update-server` ausführen, damit der server im Verzeichnis `server` verfügbar wird (dieser Schritt muss zum updaten des servers wiederholt werden)
 - GUI per `yarn start` starten
 
-### Für Windows-User
-
-- repository klonen
-- yarn und node installieren (evtl. muss auch noch [Kotlin](https://downlinko.com/download-install-kotlin-windows.html) sowie [Gradle](https://gradle.org/install/) manuell installiert werden)
-- `yarn update-server-win` ausführen, damit der server im Verzeichnis `server` verfügbar wird (dieser Schritt muss zum updaten des servers wiederholt werden)
-- GUI per `yarn start-win` starten
+### Bei Problemen mit Windows-User
+Es kann eine manuelle Installation von [Kotlin](https://downlinko.com/download-install-kotlin-windows.html) sowie [Gradle](https://gradle.org/install/) erforderlich sein, sollte die Fehlermeldung von `missing tools` auftreten.
 
 ## Allgemeine Struktur
 

--- a/main.js
+++ b/main.js
@@ -31,6 +31,7 @@ function createWindow() {
     webPreferences: {
       nodeIntegration: true,
     },
+    icon: path.join(__dirname, 'assets/build-resources/icon64.png')
   })
 
   let logDir = '.'

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "main.js",
   "scripts": {
     "test": "yarn install && yarn compile",
-    "start": "yarn update-server && yarn install && yarn compile && electron .",
+    "start": "(test -d server || yarn update-server) && yarn install && yarn compile && electron .",
     "start-dev": "yarn install && yarn compile && electron . --dev",
 
     "update-server": "git submodule update --remote && yarn compile-server",

--- a/package.json
+++ b/package.json
@@ -8,12 +8,11 @@
   "scripts": {
     "test": "yarn install && yarn compile",
     "start": "yarn install && yarn compile && (test \"hi\" && (test -d server || yarn update-server)) || echo I can\\'t test whether the server exists! && electron .",
-    "start-win": "yarn install && yarn compile && (test \"hi\" && (test -d server || yarn update-server-win)) || echo I can\\'t test whether the server exists! && electron .",
     "start-dev": "yarn install && yarn compile && electron . --dev",
+
     "update-server": "git submodule update --remote && yarn compile-server",
-    "update-server-win": "git submodule update --remote && yarn compile-server-win",
-    "compile-server": "cd socha && ./gradlew :server:deploy -q && cd .. && rimraf server && cp -r socha/server/build/runnable server && cp socha/player/build/libs/defaultplayer.jar .",
-    "compile-server-win": "cd socha && ./gradlew :server:deploy -q && cd .. && rimraf server && xcopy socha\\server\\build\\runnable server\\ /E && xcopy socha\\player\\build\\libs\\defaultplayer.jar .",
+    "compile-server": "cd socha && ./gradlew :server:deploy -q && cd .. && rimraf server && (test \"hi\" && (cp -r socha/server/build/runnable server && cp socha/player/build/libs/defaultplayer.jar .)) || (xcopy socha\\server\\build\\runnable server\\ /E && xcopy socha\\player\\build\\libs\\defaultplayer.jar .)",
+    
     "dist": "yarn install && yarn compile && electron-builder",
     "dist-all": "rimraf dist && yarn dist -mwl",
     "compile": "rimraf out && tsc",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
   "main": "main.js",
   "scripts": {
     "test": "yarn install && yarn compile",
-    "start": "yarn install && yarn compile && (test \"hi\" && (test -d server || yarn update-server)) || echo I can\\'t test whether the server exists! && electron .",
+    "start": "yarn update-server && yarn install && yarn compile && electron .",
     "start-dev": "yarn install && yarn compile && electron . --dev",
 
     "update-server": "git submodule update --remote && yarn compile-server",
-    "compile-server": "cd socha && ./gradlew :server:deploy -q && cd .. && rimraf server && (test \"hi\" && (cp -r socha/server/build/runnable server && cp socha/player/build/libs/defaultplayer.jar .)) || (xcopy socha\\server\\build\\runnable server\\ /E && xcopy socha\\player\\build\\libs\\defaultplayer.jar .)",
-    
+    "compile-server": "cd socha && ./gradlew :server:deploy -q && cd .. && rimraf server && cp -r socha/server/build/runnable server && cp socha/player/build/libs/defaultplayer.jar .",
+
     "dist": "yarn install && yarn compile && electron-builder",
     "dist-all": "rimraf dist && yarn dist -mwl",
     "compile": "rimraf out && tsc",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
       "allowToChangeInstallationDirectory": true
     },
     "mac": {
+      "icon": "assets/build-resources/icon.icns",
       "category": "public.app-category.developer-tools",
       "target": [
         "zip"
@@ -61,9 +62,13 @@
       ]
     },
     "linux": {
+      "icon": "assets/build-resources/icon.png",
       "target": [
         "AppImage"
       ]
+    },
+    "win": {
+      "icon": "assets/build-resources/icon.png"
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "main.js",
   "scripts": {
     "test": "yarn install && yarn compile",
-    "start": "(test -d server || yarn update-server) && yarn install && yarn compile && electron .",
+    "start": "yarn install && yarn compile && (test -d server || yarn update-server) && electron .",
     "start-dev": "yarn install && yarn compile && electron . --dev",
 
     "update-server": "git submodule update --remote && yarn compile-server",

--- a/package.json
+++ b/package.json
@@ -8,11 +8,12 @@
   "scripts": {
     "test": "yarn install && yarn compile",
     "start": "yarn install && yarn compile && (test \"hi\" && (test -d server || yarn update-server)) || echo I can\\'t test whether the server exists! && electron .",
+    "start-win": "yarn install && yarn compile && (test \"hi\" && (test -d server || yarn update-server-win)) || echo I can\\'t test whether the server exists! && electron .",
     "start-dev": "yarn install && yarn compile && electron . --dev",
-
     "update-server": "git submodule update --remote && yarn compile-server",
+    "update-server-win": "git submodule update --remote && yarn compile-server-win",
     "compile-server": "cd socha && ./gradlew :server:deploy -q && cd .. && rimraf server && cp -r socha/server/build/runnable server && cp socha/player/build/libs/defaultplayer.jar .",
-
+    "compile-server-win": "cd socha && ./gradlew :server:deploy -q && cd .. && rimraf server && xcopy socha\\server\\build\\runnable server\\ /E && xcopy socha\\player\\build\\libs\\defaultplayer.jar .",
     "dist": "yarn install && yarn compile && electron-builder",
     "dist-all": "rimraf dist && yarn dist -mwl",
     "compile": "rimraf out && tsc",
@@ -93,7 +94,7 @@
     "@types/sax": "^1.0.0",
     "electron": "^5.0.0",
     "electron-builder": "^20.39.0",
-    "rimraf": "^2.6.3",
+    "rimraf": "^2.7.1",
     "ts-node": "^8.1.0",
     "tslint": "^5.16.0",
     "typescript": "^3.4.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2228,10 +2228,10 @@ retry@^0.10.0:
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
   integrity sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
 
-rimraf@^2.6.3:
-  version "2.6.3"
-  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.3.tgz#b2d104fe0d8fb27cf9e0a1cda8262dd3833c6cab"
-  integrity sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==
+rimraf@^2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
 


### PR DESCRIPTION
- yarn-Commands sind jetzt unter Windows ausführbar
- README Problemlösung für Windows angepasst
- App-Icon der Software-Challenge hinzugefügt (Nur für Windows verifiziert)
