### PR TITLE
chore(electron): configure auto-updater to not use "v"-prefix

### DIFF
--- a/main.js
+++ b/main.js
@@ -42,6 +42,12 @@ function appUpdater() {
   })
 
   // init for updates
+  autoUpdater.setFeedURL({
+    provider: 'github',
+    repo: 'socha-gui',
+    owner: 'CAU-Kiel-Tech-Inf',
+    vPrefixedTagName: false
+  })
   autoUpdater.checkForUpdates()
 }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
   "scripts": {
     "pretest": "rimraf out && tsc -p tests",
     "test": "jasmine --config=jasmine.json --reporter=jasmine-ts-console-reporter",
+    "set-config": "yarn config set version-tag-prefix \"\" && yarn config set version-git-message \"release: %s\"",
+    "postversion": "git push --tags",
     "start": "yarn install && yarn compile && (test -d server || yarn update-server) && electron .",
     "start-dev": "yarn install && yarn compile && electron . --dev",
     "update-server": "git submodule update --remote && yarn compile-server",


### PR DESCRIPTION
The default setting for the electron-autoupdater when using GitHub is to
check for tags with a prefixed "v" and the version. This can be switched
off by calling setFeedURL[1] with GitHub options hash[2]. Unfortunately, this
leads to repeating the repository name and owner there, which is
otherwise detected automatically from the package.json.

[1] https://www.electron.build/auto-update#module_electron-updater.AppUpdater+setFeedURL
[2] https://www.electron.build/configuration/publish#githuboptions